### PR TITLE
Add support for Rack2 and Rack3.

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,9 +10,11 @@ env:
 
 jobs:
   test:
-    name: ${{matrix.ruby}} on ${{matrix.os}}
+    name: ${{matrix.ruby}} on ${{matrix.os}} ${{matrix.gemfile}}
     runs-on: ${{matrix.os}}-latest
     continue-on-error: ${{matrix.experimental}}
+    env:
+      BUNDLER_GEMFILE: ${{matrix.gemfile}}
     
     strategy:
       matrix:
@@ -24,6 +26,11 @@ jobs:
           - "2.7"
           - "3.0"
           - "3.1"
+        
+        gemfile:
+          - gems/rack-v1.rb
+          - gems/rack-v2.rb
+          - gems/rack-v3.rb
         
         experimental: [false]
         

--- a/gems.rb
+++ b/gems.rb
@@ -14,6 +14,5 @@ group :test do
 	gem 'bake-test'
 	gem 'bake-test-external'
 	
-	gem 'async-io'
-	gem 'async-rspec'
+	gem 'async-http'
 end

--- a/gems/rack-v1.rb
+++ b/gems/rack-v1.rb
@@ -1,0 +1,3 @@
+eval_gemfile("../gems.rb")
+
+gem "rack", "~> 1.0"

--- a/gems/rack-v2.rb
+++ b/gems/rack-v2.rb
@@ -1,0 +1,3 @@
+eval_gemfile("../gems.rb")
+
+gem "rack", "~> 2.0"

--- a/gems/rack-v3.rb
+++ b/gems/rack-v3.rb
@@ -1,0 +1,3 @@
+eval_gemfile("../gems.rb")
+
+gem "rack", "~> 3.0.0.beta1"

--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+# Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'console'
+
+require_relative '../constants'
+require_relative '../input'
+require_relative '../response'
+
+module Protocol
+	module Rack
+		module Adapter
+			class Generic
+				def self.wrap(app)
+					self.new(app)
+				end
+				
+				# Initialize the rack adaptor middleware.
+				# @parameter app [Object] The rack middleware.
+				def initialize(app)
+					@app = app
+					
+					raise ArgumentError, "App must be callable!" unless @app.respond_to?(:call)
+				end
+				
+				def logger
+					Console.logger
+				end
+
+				# Unwrap raw HTTP headers into the CGI-style expected by Rack middleware.
+				#
+				# Rack separates multiple headers with the same key, into a single field with multiple lines.
+				#
+				# @parameter headers [Protocol::HTTP::Headers] The raw HTTP request headers.
+				# @parameter env [Hash] The rack request `env`.
+				def unwrap_headers(headers, env)
+					headers.each do |key, value|
+						http_key = "HTTP_#{key.upcase.tr('-', '_')}"
+						
+						if current_value = env[http_key]
+							env[http_key] = "#{current_value};#{value}"
+						else
+							env[http_key] = value
+						end
+					end
+				end
+				
+				# Process the incoming request into a valid rack `env`.
+				#
+				# - Set the `env['CONTENT_TYPE']` and `env['CONTENT_LENGTH']` based on the incoming request body. 
+				# - Set the `env['HTTP_HOST']` header to the request authority.
+				# - Set the `env['HTTP_X_FORWARDED_PROTO']` header to the request scheme.
+				# - Set `env['REMOTE_ADDR']` to the request remote adress.
+				#
+				# @parameter request [Protocol::HTTP::Request] The incoming request.
+				# @parameter env [Hash] The rack `env`.
+				def unwrap_request(request, env)
+					if content_type = request.headers.delete('content-type')
+						env[CGI::CONTENT_TYPE] = content_type
+					end
+					
+					# In some situations we don't know the content length, e.g. when using chunked encoding, or when decompressing the body.
+					if body = request.body and length = body.length
+						env[CGI::CONTENT_LENGTH] = length.to_s
+					end
+					
+					self.unwrap_headers(request.headers, env)
+					
+					# HTTP/2 prefers `:authority` over `host`, so we do this for backwards compatibility.
+					env[CGI::HTTP_HOST] ||= request.authority
+								
+					if request.respond_to?(:remote_address)
+						if remote_address = request.remote_address
+							env[CGI::REMOTE_ADDR] = remote_address.ip_address if remote_address.ip?
+						end
+					end
+				end
+				
+				# Build a rack `env` from the incoming request and apply it to the rack middleware.
+				#
+				# @parameter request [Protocol::HTTP::Request] The incoming request.
+				def call(request)
+					env = self.make_env(request)
+					
+					status, headers, body = @app.call(env)
+					
+					return Response.wrap(status, headers, body, request)
+				rescue => exception
+					Console.logger.error(self) {exception}
+					
+					body&.close if body.respond_to?(:close)
+
+					return failure_response(exception)
+				end
+				
+				private
+
+				# Generate a suitable response for the given exception.
+				# @parameter exception [Exception]
+				# @returns [Protocol::HTTP::Response]
+				def failure_response(exception)
+					Protocol::HTTP::Response.for_exception(exception)
+				end
+			end
+		end
+	end
+end

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+# Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'console'
+
+require_relative 'generic'
+require_relative '../rewindable'
+
+module Protocol
+	module Rack
+		module Adapter
+			class Rack2	< Generic
+				RACK_VERSION = 'rack.version'
+				RACK_MULTITHREAD = 'rack.multithread'
+				RACK_MULTIPROCESS = 'rack.multiprocess'
+				RACK_RUN_ONCE = 'rack.run_once'
+				
+				def self.wrap(app)
+					Rewindable.new(self.new(app))
+				end
+				
+				def make_env(request)
+					request_path, query_string = request.path.split('?', 2)
+					server_name, server_port = (request.authority || '').split(':', 2)
+					
+					env = {
+						RACK_VERSION => [2, 0],
+						RACK_MULTITHREAD => false,
+						RACK_MULTIPROCESS => true,
+						RACK_RUN_ONCE => false,
+						
+						PROTOCOL_HTTP_REQUEST => request,
+						
+						RACK_INPUT => Input.new(request.body),
+						RACK_ERRORS => $stderr,
+						RACK_LOGGER => self.logger,
+
+						# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
+						RACK_PROTOCOL => request.protocol,
+						
+						# The HTTP request method, such as “GET” or “POST”. This cannot ever be an empty string, and so is always required.
+						CGI::REQUEST_METHOD => request.method,
+						
+						# The initial portion of the request URL's “path” that corresponds to the application object, so that the application knows its virtual “location”. This may be an empty string, if the application corresponds to the “root” of the server.
+						CGI::SCRIPT_NAME => '',
+						
+						# The remainder of the request URL's “path”, designating the virtual “location” of the request's target within the application. This may be an empty string, if the request URL targets the application root and does not have a trailing slash. This value may be percent-encoded when originating from a URL.
+						CGI::PATH_INFO => request_path,
+						CGI::REQUEST_PATH => request_path,
+						CGI::REQUEST_URI => request.path,
+
+						# The portion of the request URL that follows the ?, if any. May be empty, but is always required!
+						CGI::QUERY_STRING => query_string || '',
+						
+						# The server protocol (e.g. HTTP/1.1):
+						CGI::SERVER_PROTOCOL => request.version,
+						
+						# The request scheme:
+						RACK_URL_SCHEME => request.scheme,
+						
+						# I'm not sure what sane defaults should be here:
+						CGI::SERVER_NAME => server_name,
+						CGI::SERVER_PORT => server_port,
+					}
+					
+					self.unwrap_request(request, env)
+					
+					return env
+				end
+			end
+		end
+	end
+end

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Copyright, 2017, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'console'
+
+require_relative 'generic'
+
+module Protocol
+	module Rack
+		module Adapter
+			class Rack3
+				def self.wrap(app)
+					self.new(app)
+				end
+				
+				def make_env(request)
+					request_path, query_string = request.path.split('?', 2)
+					server_name, server_port = (request.authority || '').split(':', 2)
+					
+					env = {
+						PROTOCOL_HTTP_REQUEST => request,
+						
+						RACK_INPUT => Input.new(request.body),
+						RACK_ERRORS => $stderr,
+						RACK_LOGGER => self.logger,
+
+						# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
+						RACK_PROTOCOL => request.protocol,
+						
+						# The HTTP request method, such as “GET” or “POST”. This cannot ever be an empty string, and so is always required.
+						CGI::REQUEST_METHOD => request.method,
+						
+						# The initial portion of the request URL's “path” that corresponds to the application object, so that the application knows its virtual “location”. This may be an empty string, if the application corresponds to the “root” of the server.
+						CGI::SCRIPT_NAME => '',
+						
+						# The remainder of the request URL's “path”, designating the virtual “location” of the request's target within the application. This may be an empty string, if the request URL targets the application root and does not have a trailing slash. This value may be percent-encoded when originating from a URL.
+						CGI::PATH_INFO => request_path,
+						CGI::REQUEST_PATH => request_path,
+						CGI::REQUEST_URI => request.path,
+
+						# The portion of the request URL that follows the ?, if any. May be empty, but is always required!
+						CGI::QUERY_STRING => query_string || '',
+						
+						# The server protocol (e.g. HTTP/1.1):
+						CGI::SERVER_PROTOCOL => request.version,
+						
+						# The request scheme:
+						RACK_URL_SCHEME => request.scheme,
+						
+						# I'm not sure what sane defaults should be here:
+						CGI::SERVER_NAME => server_name,
+						CGI::SERVER_PORT => server_port,
+					}
+					
+					self.unwrap_request(request, env)
+					
+					return env
+				end
+			end
+		end
+	end
+end

--- a/lib/protocol/rack/constants.rb
+++ b/lib/protocol/rack/constants.rb
@@ -29,6 +29,9 @@ require 'console'
 
 module Protocol
 	module Rack
+		# Used for injecting the raw request in the the rack environment.
+		PROTOCOL_HTTP_REQUEST = "protocol.http.request"
+		
 		# CGI keys <https://tools.ietf.org/html/rfc3875#section-4.1>:
 		module CGI
 			HTTP_HOST = 'HTTP_HOST'

--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -82,6 +82,24 @@ module Protocol
 				return nil
 			end
 			
+			# Rewind the input stream back to the start.
+			#
+			# `rewind` must be called without arguments. It rewinds the input stream back to the beginning. It must not raise Errno::ESPIPE: that is, it may not be a pipe or a socket. Therefore, handler developers must buffer the input data into some rewindable object if the underlying input stream is not rewindable.
+			#
+			# @returns [Boolean] Whether the body could be rewound.
+			def rewind
+				if @body and @body.respond_to?(:rewind)
+					# If the body is not rewindable, this will fail.
+					@body.rewind
+					@buffer = nil
+					@finished = false
+					
+					return true
+				end
+				
+				return false
+			end
+			
 			# Whether the stream has been closed.
 			def closed?
 				@body.nil?

--- a/lib/protocol/rack/rewindable.rb
+++ b/lib/protocol/rack/rewindable.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+# Copyright, 2018, by Samuel G. D. Williams. <http://www.codeotaku.com>
+# 
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+# 
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+# 
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+
+require 'protocol/http/body/rewindable'
+require 'protocol/http/middleware'
+
+module Protocol
+	module Rack
+		# Content-type driven input buffering, specific to the needs of `rack`.
+		class Rewindable < ::Protocol::HTTP::Middleware
+			# Media types that require buffering.
+			BUFFERED_MEDIA_TYPES = %r{
+				application/x-www-form-urlencoded|
+				multipart/form-data|
+				multipart/related|
+				multipart/mixed
+			}x
+			
+			POST = 'POST'
+			
+			# Initialize the rewindable middleware.
+			# @parameter app [Protocol::HTTP::Middleware] The middleware to wrap.
+			def initialize(app)
+				super(app)
+			end
+			
+			# Determine whether the request needs a rewindable body.
+			# @parameter request [Protocol::HTTP::Request]
+			# @returns [Boolean]
+			def needs_rewind?(request)
+				content_type = request.headers['content-type']
+				
+				if request.method == POST and content_type.nil?
+					return true
+				end
+				
+				if BUFFERED_MEDIA_TYPES =~ content_type
+					return true
+				end
+				
+				return false
+			end
+			
+			def make_env(request)
+				@delegate.make_env(request)
+			end
+			
+			# Wrap the request body in a rewindable buffer if required.
+			# @parameter request [Protocol::HTTP::Request]
+			# @returns [Protocol::HTTP::Response] the response.
+			def call(request)
+				if body = request.body and needs_rewind?(request)
+					request.body = Protocol::HTTP::Body::Rewindable.new(body)
+				end
+				
+				return super
+			end
+		end
+	end
+end

--- a/test/protocol/rack/adapter.rb
+++ b/test/protocol/rack/adapter.rb
@@ -24,7 +24,7 @@ require 'protocol/rack/adapter'
 require 'server_context'
 require 'disable_console_context'
 
-describe Protocol::Rack::Adapter do
+describe Protocol::Rack::Adapter::Generic do
 	let(:adapter) {subject.new(lambda{})}
 	
 	with '#unwrap_headers' do
@@ -46,9 +46,11 @@ Adapter = Sus::Shared('an adapter') do
 	
 	with 'successful response' do
 		let(:app) do
-			lambda do |env|
-				[200, {}, ["Hello World!"]]
-			end
+			Rack::Lint.new(
+				lambda do |env|
+					[200, {}, ["Hello World!"]]
+				end
+			)
 		end
 		
 		let(:response) {client.get("/")}

--- a/test/protocol/rack/request.rb
+++ b/test/protocol/rack/request.rb
@@ -41,7 +41,7 @@ describe Protocol::Rack::Request do
 		end
 		
 		it "can regenerate request from generic env" do
-			env.delete(Protocol::Rack::Adapter::PROTOCOL_HTTP_REQUEST)
+			env.delete(Protocol::Rack::PROTOCOL_HTTP_REQUEST)
 			
 			wrapped_request = subject[env]
 			


### PR DESCRIPTION
This introduces transparent switching between Rack2 and Rack 3 compatible adaptors based on the currently loaded version of Rack.

### Types of Changes

- New feature.

### Testing

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
