### PR TITLE
Proxy `Streaming#empty?` to `@input`.

### DIFF
--- a/lib/protocol/rack/body/streaming.rb
+++ b/lib/protocol/rack/body/streaming.rb
@@ -41,6 +41,14 @@ module Protocol
 					end
 				end
 				
+				def empty?
+					if @input
+						@input.empty?
+					else
+						true
+					end
+				end
+				
 				# Invokes the block in a fiber which yields chunks when they are available.
 				def read
 					@output ||= Output.new(@input, @block)


### PR DESCRIPTION
The default implementation is always false which is wrong.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
