### PR TITLE
Check if the `@body` is closed before raise IOError

### DIFF
--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -18,6 +18,7 @@ module Protocol
 			# @parameter body [Protocol::HTTP::Body::Readable]
 			def initialize(body)
 				@body = body
+				@closed = false
 				
 				# Will hold remaining data in `#read`.
 				@buffer = nil
@@ -46,6 +47,8 @@ module Protocol
 			
 			# Close the input and output bodies.
 			def close(error = nil)
+				@closed = true
+				
 				if @body
 					@body.close(error)
 					@body = nil
@@ -74,7 +77,7 @@ module Protocol
 			
 			# Whether the stream has been closed.
 			def closed?
-				@body.nil?
+				@closed or @body.nil?
 			end
 			
 			# Whether there are any input chunks remaining?
@@ -87,7 +90,7 @@ module Protocol
 			def read_next
 				if @body
 					@body.read
-				else
+				elsif @closed
 					raise IOError, "Stream is not readable, input has been closed!"
 				end
 			end

--- a/test/protocol/rack/input.rb
+++ b/test/protocol/rack/input.rb
@@ -139,6 +139,14 @@ describe Protocol::Rack::Input do
 				end.not.to raise_exception(IOError)
 				expect(buffer).to be == ""
 			end
+			
+			it "can not read closed input" do
+				expect do
+					input.close
+					input.read(2, buffer)
+				end.to raise_exception(IOError)
+				expect(buffer).to be == ""
+			end
 		end
 		
 		with '#each' do

--- a/test/protocol/rack/input.rb
+++ b/test/protocol/rack/input.rb
@@ -136,7 +136,7 @@ describe Protocol::Rack::Input do
 			it "can read partial input" do
 				expect do
 					input.read(2, buffer)
-				end.to raise_exception(IOError)
+				end.not.to raise_exception(IOError)
 				expect(buffer).to be == ""
 			end
 		end


### PR DESCRIPTION
Check if the `@body` is closed before raise IOError.
It is necessary to store the closing state to distinguish the `@body` is empty or closed.

Fixes #3.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
