### PR TITLE
Allow for using alternative Console

### DIFF
--- a/gems.rb
+++ b/gems.rb
@@ -22,3 +22,5 @@ group :test do
 	gem "bake-test", "~> 0.1"
 	gem "bake-test-external", "~> 0.1"
 end
+
+gem "async-io", "~> 1.38"

--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -19,14 +19,16 @@ module Protocol
 				
 				# Initialize the rack adaptor middleware.
 				# @parameter app [Object] The rack middleware.
-				def initialize(app)
+				# @parameter console [Console] The console logger to use. Defaults to socketry/console
+				def initialize(app, console = Console)
 					@app = app
+					@console = console
 					
 					raise ArgumentError, "App must be callable!" unless @app.respond_to?(:call)
 				end
 				
 				def logger
-					Console.logger
+					@console.logger
 				end
 
 				# Unwrap raw HTTP headers into the CGI-style expected by Rack middleware.
@@ -116,7 +118,7 @@ module Protocol
 					
 					return Response.wrap(env, status, headers, meta, body, request)
 				rescue => exception
-					Console.logger.error(self) {exception}
+					@console.logger.error(self) {exception}
 					
 					body&.close if body.respond_to?(:close)
 					

--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2022-2023, by Samuel Williams.
 
-require 'console'
-
 require_relative '../constants'
 require_relative '../input'
 require_relative '../response'
@@ -13,14 +11,14 @@ module Protocol
 	module Rack
 		module Adapter
 			class Generic
-				def self.wrap(app)
-					self.new(app)
+				def self.wrap(app, console)
+					self.new(app, console)
 				end
 				
 				# Initialize the rack adaptor middleware.
 				# @parameter app [Object] The rack middleware.
 				# @parameter console [Console] The console logger to use. Defaults to socketry/console
-				def initialize(app, console = Console)
+				def initialize(app, console) 
 					@app = app
 					@console = console
 					

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2022-2023, by Samuel Williams.
 
-require 'console'
-
 require_relative 'generic'
 require_relative '../rewindable'
 
@@ -87,7 +85,7 @@ module Protocol
 					
 					return Response.wrap(env, status, headers, meta, body, request)
 				rescue => exception
-					Console.logger.error(self) {exception}
+					@console.logger.error(self) {exception}
 					
 					body&.close if body.respond_to?(:close)
 					

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -17,8 +17,8 @@ module Protocol
 				RACK_MULTIPROCESS = 'rack.multiprocess'
 				RACK_RUN_ONCE = 'rack.run_once'
 				
-				def self.wrap(app)
-					Rewindable.new(self.new(app))
+				def self.wrap(app, console)
+					Rewindable.new(self.new(app, console))
 				end
 				
 				def make_environment(request)

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2022, by Samuel Williams.
 
-require 'console'
-
 require_relative 'generic'
 
 module Protocol

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -11,8 +11,8 @@ module Protocol
 	module Rack
 		module Adapter
 			class Rack3 < Generic
-				def self.wrap(app)
-					self.new(app)
+				def self.wrap(app, console)
+					self.new(app, console)
 				end
 				
 				def make_environment(request)

--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -4,7 +4,6 @@
 # Copyright, 2022-2023, by Samuel Williams.
 # Copyright, 2023, by Genki Takiuchi.
 
-require 'async/io/buffer'
 require 'protocol/http/body/stream'
 
 module Protocol


### PR DESCRIPTION
## Types of Changes
- New feature
- Maintenance


## Contribution

Currently, the `Console` module is hard coded as the logger for the `Adapter`, making it difficult to use other loggers (that may have custom, desireable behavior). With this change, anything that implements a "Console interface", meaning anything with a `KlassOrModule.logger` method, is an acceptable `Console`. This attribute is set when the adapter is initialized. The default value for this parameter is `Console`, so existing code will not break.

One followup design question may be then whether having `socketry/console` be a dependency makes sense, given that users may not use this specific console implementation

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).

I think additional tests are not needed.
