### PR TITLE
Remove socketry/console dependency to allow for alternative consoles

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -19,14 +19,16 @@ module Protocol
 				
 				# Initialize the rack adaptor middleware.
 				# @parameter app [Object] The rack middleware.
-				def initialize(app)
+				# @parameter console [Console] The console logger to use. Defaults to socketry/console
+				def initialize(app, console = Console)
 					@app = app
+					@console = console
 					
 					raise ArgumentError, "App must be callable!" unless @app.respond_to?(:call)
 				end
 				
 				def logger
-					Console.logger
+					@console.logger
 				end
 
 				# Unwrap raw HTTP headers into the CGI-style expected by Rack middleware.
@@ -116,7 +118,7 @@ module Protocol
 					
 					return Response.wrap(env, status, headers, meta, body, request)
 				rescue => exception
-					Console.logger.error(self) {exception}
+					@console.logger.error(self) {exception}
 					
 					body&.close if body.respond_to?(:close)
 					

--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -3,8 +3,6 @@
 # Released under the MIT License.
 # Copyright, 2022-2023, by Samuel Williams.
 
-require 'console'
-
 require_relative '../constants'
 require_relative '../input'
 require_relative '../response'
@@ -13,14 +11,14 @@ module Protocol
 	module Rack
 		module Adapter
 			class Generic
-				def self.wrap(app)
-					self.new(app)
+				def self.wrap(app, console)
+					self.new(app, console)
 				end
 				
 				# Initialize the rack adaptor middleware.
 				# @parameter app [Object] The rack middleware.
 				# @parameter console [Console] The console logger to use. Defaults to socketry/console
-				def initialize(app, console = Console)
+				def initialize(app, console) 
 					@app = app
 					@console = console
 					

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -17,8 +17,8 @@ module Protocol
 				RACK_MULTIPROCESS = 'rack.multiprocess'
 				RACK_RUN_ONCE = 'rack.run_once'
 				
-				def self.wrap(app)
-					Rewindable.new(self.new(app))
+				def self.wrap(app, console)
+					Rewindable.new(self.new(app, console))
 				end
 				
 				def make_environment(request)

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -11,8 +11,8 @@ module Protocol
 	module Rack
 		module Adapter
 			class Rack3 < Generic
-				def self.wrap(app)
-					self.new(app)
+				def self.wrap(app, console)
+					self.new(app, console)
 				end
 				
 				def make_environment(request)


### PR DESCRIPTION
<!--
What changes are being made? What problem are you solving?
What feature/bug is being fixed here?
If this is an aesthetic change, please include screenshots.
Link to any relevant issues.
-->

Currently, socketry/console is [hardcoded ](https://github.com/socketry/protocol-rack/blob/ec318a60b894553633a43e62d78de07153274cdd/lib/protocol/rack/adapter/generic.rb#L29) as the only possible console. This change would allow people to use different console implementations

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Modularity
- Breaking change.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

**Tests would need to be modified to match the new signature for wrap**
- [ ] I added tests for my changes.
- [ ] I tested my changes locally.
- [v] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
