### PR TITLE
Tidy up usage of `Console` logger.

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -31,9 +31,9 @@ module Protocol
 				end
 				
 				def logger
-					Console.logger
+					Console
 				end
-
+				
 				# Unwrap raw HTTP headers into the CGI-style expected by Rack middleware.
 				#
 				# Rack separates multiple headers with the same key, into a single field with multiple lines.
@@ -121,7 +121,7 @@ module Protocol
 					
 					return Response.wrap(env, status, headers, meta, body, request)
 				rescue => exception
-					Console.logger.error(self) {exception}
+					Console.error(self, exception)
 					
 					body&.close if body.respond_to?(:close)
 					

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -87,7 +87,7 @@ module Protocol
 					
 					return Response.wrap(env, status, headers, meta, body, request)
 				rescue => exception
-					Console.logger.error(self) {exception}
+					Console.error(self, exception)
 					
 					body&.close if body.respond_to?(:close)
 					

--- a/lib/protocol/rack/response.rb
+++ b/lib/protocol/rack/response.rb
@@ -43,7 +43,7 @@ module Protocol
 				ignored = headers.extract(HOP_HEADERS)
 				
 				unless ignored.empty?
-					Console.logger.warn(self, "Ignoring protocol-level headers: #{ignored.inspect}")
+					Console.warn(self, "Ignoring hop headers!", ignored: ignored)
 				end
 
 				if hijack_body = meta['rack.hijack']


### PR DESCRIPTION
Tidy up usage of the `Console` gem, don't pass around `Console.logger`.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
