### PR TITLE
Prefer to use `Fiber#transfer` for reading/writing streaming chunks.

### DIFF
--- a/test/protocol/rack/body/streaming.rb
+++ b/test/protocol/rack/body/streaming.rb
@@ -38,4 +38,18 @@ describe Protocol::Rack::Body::Streaming do
 			expect(stream.string).to be == "HelloWorld"
 		end
 	end
+	
+	with "nested fiber" do
+		let(:block) do
+			proc do |stream|
+				Fiber.new do
+					stream.write("Hello")
+				end.resume
+			end
+		end
+		
+		it "can read a chunk" do
+			expect(body.read).to be == "Hello"
+		end
+	end
 end


### PR DESCRIPTION
`Fiber.yield` is unpredictable, it may yield to the wrong fiber if used in a nested context.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
