### PR TITLE
If the user reads exactly the content length, rack expects the input to be closed.

### DIFF
--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -89,6 +89,13 @@ module Protocol
 				if @body
 					# User's may forget to call #close...
 					if chunk = @body.read
+						# If the user reads exactly the content length, we close the stream automatically:
+						# https://github.com/socketry/async-http/issues/183
+						if @body.empty?
+							@body.close
+							@body = nil
+						end
+						
 						return chunk
 					else
 						# So if we are at the end of the stream, we close it automatically:

--- a/test/protocol/rack/input.rb
+++ b/test/protocol/rack/input.rb
@@ -52,6 +52,12 @@ describe Protocol::Rack::Input do
 				expect(input.body).to be_nil
 			end
 			
+			it "can read exactly the content length" do
+				expect(body).to receive(:close)
+				
+				expect(input.read(sample_data.join.bytesize)).to be == sample_data.join
+			end
+			
 			it "can read no input" do
 				expect(input.read(0)).to be == ""
 			end


### PR DESCRIPTION
Fixes <https://github.com/socketry/async-http/issues/183>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
