### PR TITLE
Don't assign `nil` to `rack.protocol`.

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -74,6 +74,11 @@ module Protocol
 				# @parameter request [Protocol::HTTP::Request] The incoming request.
 				# @parameter env [Hash] The rack `env`.
 				def unwrap_request(request, env)
+					# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
+					if protocol = request.protocol
+						env[RACK_PROTOCOL] = protocol
+					end
+					
 					if content_type = request.headers.delete("content-type")
 						env[CGI::CONTENT_TYPE] = content_type
 					end

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -37,9 +37,6 @@ module Protocol
 						RACK_ERRORS => $stderr,
 						RACK_LOGGER => self.logger,
 
-						# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
-						RACK_PROTOCOL => request.protocol,
-						
 						# The HTTP request method, such as “GET” or “POST”. This cannot ever be an empty string, and so is always required.
 						CGI::REQUEST_METHOD => request.method,
 						

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -30,9 +30,6 @@ module Protocol
 						RACK_ERRORS => $stderr,
 						RACK_LOGGER => self.logger,
 						
-						# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
-						RACK_PROTOCOL => request.protocol,
-						
 						# The response finished callbacks:
 						RACK_RESPONSE_FINISHED => [],
 						

--- a/lib/protocol/rack/adapter/rack31.rb
+++ b/lib/protocol/rack/adapter/rack31.rb
@@ -21,9 +21,6 @@ module Protocol
 						RACK_ERRORS => $stderr,
 						RACK_LOGGER => self.logger,
 						
-						# The request protocol, either from the upgrade header or the HTTP/2 pseudo header of the same name.
-						RACK_PROTOCOL => request.protocol,
-						
 						# The response finished callbacks:
 						RACK_RESPONSE_FINISHED => [],
 						


### PR DESCRIPTION
`rack.protocol` (on the request side) is an optional Array of String values. We shouldn't set it to `nil` unless it is known.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Maintenance.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
