### PR TITLE
Stop setting SERVER_PORT env key if nil

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -106,6 +106,9 @@ module Protocol
 					if peer = request.peer
 						env[CGI::REMOTE_ADDR] = peer.ip_address
 					end
+
+					# SERVER_PORT should not be set if it is nil
+					env.delete(CGI::SERVER_PORT) if env[CGI::SERVER_PORT].nil?
 				end
 				
 				def make_environment(request)

--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -106,9 +106,6 @@ module Protocol
 					if peer = request.peer
 						env[CGI::REMOTE_ADDR] = peer.ip_address
 					end
-
-					# SERVER_PORT should not be set if it is nil
-					env.delete(CGI::SERVER_PORT) if env[CGI::SERVER_PORT].nil?
 				end
 				
 				def make_environment(request)

--- a/lib/protocol/rack/adapter/rack2.rb
+++ b/lib/protocol/rack/adapter/rack2.rb
@@ -59,8 +59,12 @@ module Protocol
 						
 						# I'm not sure what sane defaults should be here:
 						CGI::SERVER_NAME => server_name,
-						CGI::SERVER_PORT => server_port,
 					}
+
+					# SERVER_PORT is optional but must not be set if it is not present.
+					if server_port
+						env[CGI::SERVER_PORT] = server_port
+					end
 					
 					self.unwrap_request(request, env)
 					

--- a/lib/protocol/rack/adapter/rack3.rb
+++ b/lib/protocol/rack/adapter/rack3.rb
@@ -55,8 +55,12 @@ module Protocol
 						
 						# I'm not sure what sane defaults should be here:
 						CGI::SERVER_NAME => server_name,
-						CGI::SERVER_PORT => server_port,
 					}
+
+					# SERVER_PORT is optional but must not be set if it is not present.
+					if server_port
+						env[CGI::SERVER_PORT] = server_port
+					end
 					
 					self.unwrap_request(request, env)
 					

--- a/lib/protocol/rack/adapter/rack31.rb
+++ b/lib/protocol/rack/adapter/rack31.rb
@@ -46,8 +46,12 @@ module Protocol
 						
 						# I'm not sure what sane defaults should be here:
 						CGI::SERVER_NAME => server_name,
-						CGI::SERVER_PORT => server_port,
 					}
+
+					# SERVER_PORT is optional but must not be set if it is not present.
+					if server_port
+						env[CGI::SERVER_PORT] = server_port
+					end
 					
 					if body = request.body
 						if body.empty?

--- a/test/protocol/rack/adapter/generic.rb
+++ b/test/protocol/rack/adapter/generic.rb
@@ -35,6 +35,18 @@ describe Protocol::Rack::Adapter::Generic do
 			expect(env).to have_keys("CONTENT_TYPE" => be == "text/plain")
 		end
 	end
+
+	with "app server without SERVER_PORT" do
+    let(:request) do
+      Protocol::HTTP::Request.new("https", "example.com", "GET", "/", "http/1.1", Protocol::HTTP::Headers[{"accept" => "text/html"}], nil)
+    end
+
+    it "does not include SERVER_PORT in the Rack environment" do
+      env = adapter.make_environment(request)
+      
+      expect(env).not.to have_keys(Protocol::Rack::CGI::SERVER_PORT)
+    end
+  end
 	
 	with "a app that returns nil" do
 		include DisableConsoleContext


### PR DESCRIPTION
The `SERVER_PORT` is optional but must not be set if it is not present.

Fixes <https://github.com/socketry/falcon/issues/118>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
