### PR TITLE
Ignore/close body for no entity body status codes.

### DIFF
--- a/test/protocol/rack/body.rb
+++ b/test/protocol/rack/body.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# Released under the MIT License.
+# Copyright, 2024, by Samuel Williams.
+
+require "protocol/rack/body"
+require "protocol/http/body/readable"
+require "console"
+
+describe Protocol::Rack::Body do
+	with "#no_content?" do
+		it "returns true for status codes that indicate no content" do
+			expect(subject.no_content?(204)).to be == true
+			expect(subject.no_content?(205)).to be == true
+			expect(subject.no_content?(304)).to be == true
+			expect(subject.no_content?(200)).to be == false
+		end
+	end
+	
+	with "#wrap" do
+		let(:env) { {} }
+		let(:headers) { {} }
+		
+		it "handles nil body" do
+			expect(Console).to receive(:warn).and_return(nil)
+			
+			result = subject.wrap(env, 200, headers, nil)
+			expect(result).to be_nil
+		end
+		
+		with "non-empty body and no-content status" do
+			let(:mock_body) do
+				Protocol::HTTP::Body::Buffered.new(["content"])
+			end
+			
+			[204, 205, 304].each do |status|
+				it "closes body and returns nil for status #{status}", unique: status do
+					expect(Console).to receive(:warn).and_return(nil)
+					expect(mock_body).to receive(:close)
+					
+					result = subject.wrap(env, status, headers, mock_body)
+					
+					expect(result).to be_nil
+				end
+			end
+		end
+		
+		with "empty body and no-content status" do
+			let(:mock_body) do
+				Protocol::HTTP::Body::Buffered.new
+			end
+			
+			it "closes body and returns nil for no-content status" do
+				expect(Console).not.to receive(:warn)
+				expect(mock_body).to receive(:close)
+				
+				result = subject.wrap(env, 204, headers, mock_body)
+				
+				expect(result).to be_nil
+			end
+		end
+		
+		with "body and normal status" do
+			let(:mock_body) do
+				body = Object.new
+				
+				def body.each
+					yield "content"
+				end
+				
+				body
+			end
+			
+			it "wraps body properly with status 200" do
+				result = subject.wrap(env, 200, headers, mock_body)
+				expect(result).to be_a(Protocol::Rack::Body::Enumerable)
+				expect(result).not.to be_nil
+			end
+		end
+	end
+end


### PR DESCRIPTION
Rack applications sometimes incorrectly return non-empty bodies for status codes which should not have an entity body. In those cases, we close and ignore the body (and warn if appropriate).

If we don't do this, we may incorrectly send a response body causing the remote end to give up, resulting in EPIPE: <https://github.com/socketry/falcon/issues/289>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- New feature.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
