### PR TITLE
Fix handling of rewind after reading all input.

### DIFF
--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -93,14 +93,18 @@ module Protocol
 						# https://github.com/socketry/async-http/issues/183
 						if @body.empty?
 							@body.close
-							@body = nil
+							@closed = true
 						end
 						
 						return chunk
 					else
-						# So if we are at the end of the stream, we close it automatically:
-						@body.close
-						@body = nil
+						unless @closed
+							# So if we are at the end of the stream, we close it automatically:
+							@body.close
+							@closed = true
+						end
+						
+						return nil
 					end
 				elsif @closed
 					raise IOError, "Stream is not readable, input has been closed!"

--- a/lib/protocol/rack/input.rb
+++ b/lib/protocol/rack/input.rb
@@ -64,8 +64,10 @@ module Protocol
 				if @body and @body.respond_to?(:rewind)
 					# If the body is not rewindable, this will fail.
 					@body.rewind
+					
 					@buffer = nil
 					@finished = false
+					@closed = false
 					
 					return true
 				end

--- a/test/protocol/rack/input.rb
+++ b/test/protocol/rack/input.rb
@@ -49,7 +49,14 @@ describe Protocol::Rack::Input do
 				expect(input.read).to be == sample_data.join
 				expect(input.read).to be == ""
 				
-				expect(input.body).to be_nil
+				expect(input).to be(:closed?)
+			end
+			
+			it "can rewind after reading all input" do
+				expect(input.read).to be == sample_data.join
+				input.rewind
+				
+				expect(input.read).to be == sample_data.join
 			end
 			
 			it "can read exactly the content length" do
@@ -69,13 +76,20 @@ describe Protocol::Rack::Input do
 				expect(input.read(3)).to be == "row"
 			end
 			
+			it "can rewind after reading partial input" do
+				expect(input.read(3)).to be == "The"
+				input.rewind
+				
+				expect(input.read(3)).to be == "The"
+			end
+			
 			it "can read all input" do
 				expect(input.read(15)).to be == sample_data.join[0...15]
 				expect(input.read).to be == sample_data.join[15..-1]
 				
 				expect(input.read(1)).to be == nil
 				
-				expect(input.body).to be_nil
+				expect(input).to be(:closed?)
 			end
 			
 			it "can read partial input with buffer" do

--- a/test/protocol/rack/input.rb
+++ b/test/protocol/rack/input.rb
@@ -54,8 +54,11 @@ describe Protocol::Rack::Input do
 			
 			it "can rewind after reading all input" do
 				expect(input.read).to be == sample_data.join
+				expect(input).to be(:closed?)
+				
 				input.rewind
 				
+				expect(input).not.to be(:closed?)
 				expect(input.read).to be == sample_data.join
 			end
 			
@@ -78,8 +81,11 @@ describe Protocol::Rack::Input do
 			
 			it "can rewind after reading partial input" do
 				expect(input.read(3)).to be == "The"
+				expect(input).not.to be(:closed?)
+				
 				input.rewind
 				
+				expect(input).not.to be(:closed?)
 				expect(input.read(3)).to be == "The"
 			end
 			


### PR DESCRIPTION
Fixes an issue where `#rewind` no longer works if the entire body is read, causing an implicit close.

Fixes <https://github.com/socketry/protocol-rack/pull/24>.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
