### PR TITLE
Fix head request handling.

### DIFF
--- a/lib/protocol/rack/body.rb
+++ b/lib/protocol/rack/body.rb
@@ -37,8 +37,9 @@ module Protocol
 			# @parameter headers [Hash] The response headers.
 			# @parameter body [Object] The response body to wrap.
 			# @parameter input [Object] Optional input for streaming bodies.
+			# @parameter head [Boolean] Indicates if this is a HEAD request, which should not have a body.
 			# @returns [Protocol::HTTP::Body] The wrapped response body.
-			def self.wrap(env, status, headers, body, input = nil)
+			def self.wrap(env, status, headers, body, input = nil, head = false)
 				# In no circumstance do we want this header propagating out:
 				if length = headers.delete(CONTENT_LENGTH)
 					# We don't really trust the user to provide the right length to the transport.
@@ -81,6 +82,14 @@ module Protocol
 						body = ::Protocol::HTTP::Body::Completable.new(body, completion_callback(response_finished, env, status, headers))
 					else
 						completion_callback(response_finished, env, status, headers).call(nil)
+					end
+				end
+				
+				if head
+					if body
+						body = ::Protocol::HTTP::Body::Head.for(body)
+					elsif length
+						body = ::Protocol::HTTP::Body::Head.new(length)
 					end
 				end
 				

--- a/lib/protocol/rack/response.rb
+++ b/lib/protocol/rack/response.rb
@@ -50,12 +50,7 @@ module Protocol
 					body = hijack_body
 				end
 
-				body = Body.wrap(env, status, headers, body, request&.body)
-
-				if request&.head?
-					# I thought about doing this in Output.wrap, but decided the semantics are too tricky. Specifically, the various ways a rack response body can be wrapped, and the need to invoke #close at the right point.
-					body = ::Protocol::HTTP::Body::Head.for(body)
-				end
+				body = Body.wrap(env, status, headers, body, request&.body, request&.head?)
 				
 				protocol = meta[RACK_PROTOCOL]
 				

--- a/test/protocol/rack/body.rb
+++ b/test/protocol/rack/body.rb
@@ -18,14 +18,50 @@ describe Protocol::Rack::Body do
 	end
 	
 	with "#wrap" do
-		let(:env) { {} }
-		let(:headers) { {} }
+		let(:env) {Hash.new}
+		let(:headers) {Hash.new}
 		
 		it "handles nil body" do
 			expect(Console).to receive(:warn).and_return(nil)
 			
 			result = subject.wrap(env, 200, headers, nil)
 			expect(result).to be_nil
+		end
+		
+		with "head request" do
+			it "handles head request with content-length and empty body" do
+				headers["content-length"] = "123"
+				
+				result = subject.wrap(env, 200, headers, [], nil, true)
+				
+				expect(result).to be_a(Protocol::HTTP::Body::Head)
+				expect(result.length).to be == 123
+			end
+			
+			it "handles head request with no content-length and empty body" do
+				result = subject.wrap(env, 200, headers, [], nil, true)
+				
+				expect(result).to be_a(Protocol::HTTP::Body::Head)
+				expect(result.length).to be == 0
+			end
+			
+			it "handles head request with content-length and nil body" do
+				headers["content-length"] = "123"
+				
+				expect(Console).to receive(:warn).and_return(nil)
+				result = subject.wrap(env, 200, headers, nil, nil, true)
+				
+				expect(result).to be_a(Protocol::HTTP::Body::Head)
+				expect(result.length).to be == 123
+			end
+			
+			it "handles head request with no content-length and nil body" do
+				expect(Console).to receive(:warn).and_return(nil)
+				
+				result = subject.wrap(env, 200, headers, nil, nil, true)
+				
+				expect(result).to be_nil
+			end
 		end
 		
 		with "non-empty body and no-content status" do


### PR DESCRIPTION
If the response body is nil, head response will not be generated correctly - `Head.for(nil)` is currently invalid.

See <https://github.com/socketry/protocol-http/pull/83> for related change.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
