### PR TITLE
Don't dup hijacked io - it's not possible with `SSLSocket`.

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -114,7 +114,7 @@ module Protocol
 					
 					if request.respond_to?(:hijack?) and request.hijack?
 						env[RACK_IS_HIJACK] = true
-						env[RACK_HIJACK] = proc{request.hijack!.io.dup}
+						env[RACK_HIJACK] = proc{request.hijack!.io}
 					end
 					
 					# HTTP/2 prefers `:authority` over `host`, so we do this for backwards compatibility.


### PR DESCRIPTION
I was experimenting with WebSockets and ActionCable over TLS, and found that this was problematic.

This is mostly affecting `protocol-http1`, where previously the `IO` was not nullified after being hijacked. But now it is: https://github.com/socketry/protocol-http1/blob/58d22901b3d00030590a675203508dd71bca4628/lib/protocol/http1/connection.rb#L205

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [ ] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
