### PR TITLE
Ensure that `HTTP_HOST` is derived from the authority.

### DIFF
--- a/lib/protocol/rack/adapter/generic.rb
+++ b/lib/protocol/rack/adapter/generic.rb
@@ -117,8 +117,11 @@ module Protocol
 						env[RACK_HIJACK] = proc{request.hijack!.io}
 					end
 					
-					# HTTP/2 prefers `:authority` over `host`, so we do this for backwards compatibility.
-					env[CGI::HTTP_HOST] ||= request.authority
+					# HTTP/2 prefers `:authority` over `host`:
+					if authority = request.authority
+						# Note that we also already have SERVER_NAME and SERVER_PORT which are based on the authority.
+						env[CGI::HTTP_HOST] = authority
+					end
 					
 					if peer = request.peer
 						env[CGI::REMOTE_ADDR] = peer.ip_address


### PR DESCRIPTION
Without this change, it's possible for an HTTP/2 request with a `host` header to deviate from the `:authority` pseudo header.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.
- Security fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
