### PR TITLE
Fix streaming body close.

### DIFF
--- a/lib/protocol/rack/body/enumerable.rb
+++ b/lib/protocol/rack/body/enumerable.rb
@@ -69,12 +69,14 @@ module Protocol
 				# 
 				# @parameter error [Exception] Optional error that occurred during processing.
 				def close(error = nil)
-					if @body and @body.respond_to?(:close)
-						@body.close
-					end
-					
-					@body = nil
 					@chunks = nil
+					
+					if body = @body
+						@body = nil
+						if body.respond_to?(:close)
+							body.close
+						end
+					end
 					
 					super
 				end

--- a/lib/protocol/rack/body/streaming.rb
+++ b/lib/protocol/rack/body/streaming.rb
@@ -8,13 +8,26 @@ require "protocol/http/body/streamable"
 module Protocol
 	module Rack
 		module Body
+			# Wraps a Rack streaming response body.
+			# The body must be callable and accept a stream argument.
+			# This is typically used for Rack hijack responses or bodies wrapped in `Rack::BodyProxy`.
+			# When closed, this class ensures the wrapped body's `close` method is called if it exists.
 			class Streaming < ::Protocol::HTTP::Body::Streamable::ResponseBody
+				# Initialize the streaming body wrapper.
+				# 
+				# @parameter body [Object] A callable object that accepts a stream argument, such as a Proc or an object that responds to `call`. May optionally respond to `close` for cleanup (e.g., `Rack::BodyProxy`).
+				# @parameter input [Protocol::HTTP::Body::Readable | Nil] Optional input body for bi-directional streaming.
 				def initialize(body, input = nil)
 					@body = body
 					
 					super
 				end
 				
+				# Close the streaming body and clean up resources.
+				# If the wrapped body responds to `close`, it will be called to allow proper cleanup.
+				# This ensures that `Rack::BodyProxy` cleanup callbacks are invoked correctly.
+				# 
+				# @parameter error [Exception | Nil] Optional error that caused the stream to close.
 				def close(error = nil)
 					if body = @body
 						@body = nil

--- a/lib/protocol/rack/body/streaming.rb
+++ b/lib/protocol/rack/body/streaming.rb
@@ -8,7 +8,24 @@ require "protocol/http/body/streamable"
 module Protocol
 	module Rack
 		module Body
-			Streaming = ::Protocol::HTTP::Body::Streamable::ResponseBody
+			class Streaming < ::Protocol::HTTP::Body::Streamable::ResponseBody
+				def initialize(body, input = nil)
+					@body = body
+					
+					super
+				end
+				
+				def close(error = nil)
+					if body = @body
+						@body = nil
+						if body.respond_to?(:close)
+							body.close
+						end
+					end
+					
+					super
+				end
+			end
 		end
 	end
 end

--- a/releases.md
+++ b/releases.md
@@ -1,5 +1,9 @@
 # Releases
 
+## Unreleased
+
+  - Fix missing `body#close` for streaming bodies.
+
 ## v0.21.0
 
   - For the purpose of constructing the rack request environment, trailers are ignored.

--- a/test/protocol/rack/body/streaming.rb
+++ b/test/protocol/rack/body/streaming.rb
@@ -69,7 +69,7 @@ describe Protocol::Rack::Body::Streaming do
 		end
 		
 		it "does not fail if wrapped body does not respond to close" do
-			wrapped_body = proc { |stream| stream.write("Hello") }
+			wrapped_body = proc{|stream| stream.write("Hello")}
 			
 			body = subject.new(wrapped_body)
 			body.close

--- a/test/protocol/rack/body/streaming.rb
+++ b/test/protocol/rack/body/streaming.rb
@@ -50,4 +50,29 @@ describe Protocol::Rack::Body::Streaming do
 			expect(body.read).to be == "Hello"
 		end
 	end
+	
+	with "#close" do
+		it "closes the wrapped body if it responds to close" do
+			close_called = false
+			wrapped_body = Object.new
+			wrapped_body.define_singleton_method(:close) do
+				close_called = true
+			end
+			wrapped_body.define_singleton_method(:call) do |stream|
+				stream.write("Hello")
+			end
+			
+			body = subject.new(wrapped_body)
+			body.close
+			
+			expect(close_called).to be == true
+		end
+		
+		it "does not fail if wrapped body does not respond to close" do
+			wrapped_body = proc { |stream| stream.write("Hello") }
+			
+			body = subject.new(wrapped_body)
+			body.close
+		end
+	end
 end


### PR DESCRIPTION
Previously, `#close` was not invoked on streaming bodies from Rack, meaning that, for example, `Rack::Events` would never emit `on_finish` events.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Bug fix.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
