### PR TITLE
Prefer to use a buffered body where possible.

### DIFF
--- a/lib/protocol/rack/body/enumerable.rb
+++ b/lib/protocol/rack/body/enumerable.rb
@@ -26,7 +26,7 @@ module Protocol
 				def self.wrap(body, length = nil)
 					if body.respond_to?(:to_ary)
 						# This avoids allocating an enumerator, which is more efficient:
-						return ::Protocol::HTTP::Body::Buffered.new(body.to_ary)
+						return ::Protocol::HTTP::Body::Buffered.new(body.to_ary, length)
 					else
 						return self.new(body, length)
 					end

--- a/lib/protocol/rack/body/enumerable.rb
+++ b/lib/protocol/rack/body/enumerable.rb
@@ -4,6 +4,7 @@
 # Copyright, 2022-2026, by Samuel Williams.
 
 require "protocol/http/body/readable"
+require "protocol/http/body/buffered"
 require "protocol/http/body/file"
 
 module Protocol
@@ -23,9 +24,9 @@ module Protocol
 				# @parameter length [Integer] Optional content length of the response body.
 				# @returns [Enumerable] A new enumerable body instance.
 				def self.wrap(body, length = nil)
-					if body.is_a?(Array)
-						length ||= body.sum(&:bytesize)
-						return self.new(body, length)
+					if body.respond_to?(:to_ary)
+						# This avoids allocating an enumerator, which is more efficient:
+						return ::Protocol::HTTP::Body::Buffered.new(body.to_ary)
 					else
 						return self.new(body, length)
 					end

--- a/test/protocol/rack/adapter/rack2.rb
+++ b/test/protocol/rack/adapter/rack2.rb
@@ -59,7 +59,7 @@ describe Protocol::Rack::Adapter::Rack2 do
 				let(:app) {->(env){[200, {}, body]}}
 				
 				it "should not modify partial responses" do
-					expect(response.body).to be_a(Protocol::Rack::Body::Enumerable)
+					expect(response.body).to be_a(Protocol::HTTP::Body::Buffered)
 				end
 			end
 		end
@@ -78,7 +78,7 @@ describe Protocol::Rack::Adapter::Rack2 do
 				let(:app) {->(env){[200, {}, ["Hello"]]}}
 				
 				it "handles array response correctly" do
-					expect(response.body).to be_a(Protocol::Rack::Body::Enumerable)
+					expect(response.body).to be_a(Protocol::HTTP::Body::Buffered)
 				end
 			end
 		end

--- a/test/protocol/rack/adapter/rack3.rb
+++ b/test/protocol/rack/adapter/rack3.rb
@@ -57,7 +57,7 @@ describe Protocol::Rack::Adapter::Rack3 do
 				let(:app) {->(env){[200, {}, fake_file]}}
 				
 				it "should not modify partial responses" do
-					expect(response.body).to be(:kind_of?, Protocol::Rack::Body::Enumerable)
+					expect(response.body).to be(:kind_of?, Protocol::HTTP::Body::Buffered)
 				end
 			end
 		end

--- a/test/protocol/rack/adapter/rack31.rb
+++ b/test/protocol/rack/adapter/rack31.rb
@@ -65,7 +65,7 @@ describe Protocol::Rack::Adapter::Rack31 do
 				let(:app) {->(env){[200, {}, fake_file]}}
 				
 				it "should not modify partial responses" do
-					expect(response.body).to be(:kind_of?, Protocol::Rack::Body::Enumerable)
+					expect(response.body).to be(:kind_of?, Protocol::HTTP::Body::Buffered)
 				end
 			end
 		end

--- a/test/protocol/rack/body.rb
+++ b/test/protocol/rack/body.rb
@@ -126,6 +126,41 @@ describe Protocol::Rack::Body do
 			end
 		end
 		
+		with "array body" do
+			it "wraps array body and returns chunks via #read" do
+				result = subject.wrap(env, 200, headers, ["Hello", " ", "World"])
+				
+				expect(result).not.to be_nil
+				expect(result.read).to be == "Hello"
+				expect(result.read).to be == " "
+				expect(result.read).to be == "World"
+				expect(result.read).to be_nil
+			end
+			
+			it "wraps array body and yields chunks via #each" do
+				result = subject.wrap(env, 200, headers, ["chunk1", "chunk2"])
+				chunks = []
+				result.each{|chunk| chunks << chunk}
+				
+				expect(chunks).to be == ["chunk1", "chunk2"]
+			end
+			
+			it "wraps empty array body" do
+				result = subject.wrap(env, 200, headers, [])
+				
+				expect(result).not.to be_nil
+				expect(result).to be(:empty?)
+				expect(result.read).to be_nil
+			end
+			
+			it "uses content-length when provided" do
+				headers["content-length"] = "11"
+				result = subject.wrap(env, 200, headers, ["Hello", " World"])
+				
+				expect(result.length).to be == 11
+			end
+		end
+		
 		with "response finished callback" do
 			it "returns a body that calls the callback when closed" do
 				called = false

--- a/test/protocol/rack/body/enumerable.rb
+++ b/test/protocol/rack/body/enumerable.rb
@@ -22,6 +22,24 @@ describe Protocol::Rack::Body::Enumerable do
 		end
 	end
 	
+	with "#read" do
+		let(:body) {subject.new(["Hello", " ", "World"], 11)}
+		
+		it "returns chunks in order" do
+			expect(body.read).to be == "Hello"
+			expect(body.read).to be == " "
+			expect(body.read).to be == "World"
+			expect(body.read).to be_nil
+		end
+		
+		it "returns nil when exhausted" do
+			body.read
+			body.read
+			body.read
+			expect(body.read).to be_nil
+		end
+	end
+	
 	with "#each" do
 		let(:bad_enumerable) do
 			Enumerator.new do |yielder|


### PR DESCRIPTION
To avoid the creation of lazy enumerators, it's better to use a buffered response body.

## Types of Changes

<!-- Delete any which don't apply (feel free to modify): -->

- Performance improvement.

## Contribution

<!-- Delete any which don't apply (you don't need to check all of them initially): -->

- [x] I added tests for my changes.
- [x] I tested my changes locally.
- [x] I agree to the [Developer's Certificate of Origin 1.1](https://developercertificate.org/).
